### PR TITLE
Add Viewer role, refactor configs, and enable Swagger

### DIFF
--- a/Authentication.Domain/Enums/RoleType.cs
+++ b/Authentication.Domain/Enums/RoleType.cs
@@ -10,6 +10,7 @@ namespace Authentication.Domain.Enums
     {
         Admin = 1,
         User = 2,
-        Editor = 3
+        Editor = 3,
+        Viewer = 4
     }
 }

--- a/Authentication.Infrastructure/Migrations/20250416113756_NewRole.Designer.cs
+++ b/Authentication.Infrastructure/Migrations/20250416113756_NewRole.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Authentication.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Authentication.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250416113756_NewRole")]
+    partial class NewRole
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Authentication.Infrastructure/Migrations/20250416113756_NewRole.cs
+++ b/Authentication.Infrastructure/Migrations/20250416113756_NewRole.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Authentication.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class NewRole : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                table: "Roles",
+                columns: new[] { "Id", "Description", "Name" },
+                values: new object[] { 4, "Viewer Role", "Viewer" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Roles",
+                keyColumn: "Id",
+                keyValue: 4);
+        }
+    }
+}

--- a/Authentication.Infrastructure/Persistence/Configurations/RoleConfiguration.cs
+++ b/Authentication.Infrastructure/Persistence/Configurations/RoleConfiguration.cs
@@ -38,7 +38,8 @@ namespace Authentication.Infrastructure.Persistence.Configurations
             builder.HasData(
                 new Role { Id = (int)RoleType.Admin, Name = RoleType.Admin.ToString(), Description = $"{RoleType.Admin.ToString()} Role" },
                 new Role { Id = (int)RoleType.User, Name = RoleType.User.ToString(), Description = $"{RoleType.User.ToString()} Role" },
-                new Role { Id = (int)RoleType.Editor, Name = RoleType.Editor.ToString(), Description = $"{RoleType.Editor.ToString()} Role" }
+                new Role { Id = (int)RoleType.Editor, Name = RoleType.Editor.ToString(), Description = $"{RoleType.Editor.ToString()} Role" },
+                new Role { Id = (int)RoleType.Viewer, Name = RoleType.Viewer.ToString(), Description = $"{RoleType.Viewer.ToString()} Role" }
             );
         }
 

--- a/Authentication.Infrastructure/ServiceExtensions.cs
+++ b/Authentication.Infrastructure/ServiceExtensions.cs
@@ -19,14 +19,17 @@ namespace Authentication.Infrastructure
 
             //Add DB Context
             string connectionStringTemplate = configuration.GetConnectionString("DefaultConnection") ?? throw new InvalidOperationException("Connection string is not set");
+            string connectionString = connectionStringTemplate;
+            if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") != "Debug")
+            {
+                connectionString = connectionStringTemplate
+                    .Replace("$SQL_HOST", Environment.GetEnvironmentVariable("SQL_HOST") ?? throw new InvalidOperationException("SQL_HOST is not set"))
+                    .Replace("$SQL_PORT", Environment.GetEnvironmentVariable("SQL_PORT") ?? throw new InvalidOperationException("SQL_PORT is not set"))
+                    .Replace("$SQL_DB", Environment.GetEnvironmentVariable("SQL_DB") ?? throw new InvalidOperationException("SQL_DB is not set"))
+                    .Replace("$SQL_USER", Environment.GetEnvironmentVariable("SQL_USER") ?? throw new InvalidOperationException("SQL_USER is not set"))
+                    .Replace("$SQL_PASSWORD", Environment.GetEnvironmentVariable("SQL_PASSWORD") ?? throw new InvalidOperationException("SQL_PASSWORD is not set"));
 
-            string connectionString = connectionStringTemplate
-                .Replace("$SQL_HOST", Environment.GetEnvironmentVariable("SQL_HOST") ?? throw new InvalidOperationException("SQL_HOST is not set"))
-                .Replace("$SQL_PORT", Environment.GetEnvironmentVariable("SQL_PORT") ?? throw new InvalidOperationException("SQL_PORT is not set"))
-                .Replace("$SQL_DB", Environment.GetEnvironmentVariable("SQL_DB") ?? throw new InvalidOperationException("SQL_DB is not set"))
-                .Replace("$SQL_USER", Environment.GetEnvironmentVariable("SQL_USER") ?? throw new InvalidOperationException("SQL_USER is not set"))
-                .Replace("$SQL_PASSWORD", Environment.GetEnvironmentVariable("SQL_PASSWORD") ?? throw new InvalidOperationException("SQL_PASSWORD is not set"));
-
+            }
             services.AddDbContext<ApplicationDbContext>(options =>
             {
                 options.UseNpgsql(connectionString);

--- a/AuthenticationServer/Program.cs
+++ b/AuthenticationServer/Program.cs
@@ -86,7 +86,7 @@ using (var scope = app.Services.CreateScope())
 app.UseExceptionHandlingMiddleware();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+if (!app.Environment.IsProduction())
 {
     app.UseSwagger();
     app.UseSwaggerUI();

--- a/AuthenticationServer/appsettings.Debug.json
+++ b/AuthenticationServer/appsettings.Debug.json
@@ -1,0 +1,15 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft.AspNetCore": "Warning"
+        }
+    },
+    "ConnectionStrings": {
+        "DefaultConnection": "Server=localhost;Port=5432;Database=JwtAuthDB;User Id=postgres;Password=admin"
+    },
+    "Jwt": {
+        "Issuer": "https://localhost:7172",
+        "DisableSslValidation": true
+    }
+}


### PR DESCRIPTION
Introduced a new `Viewer` role in the `RoleType` enum, updated database seeding, and added a migration to support it. Refactored connection string handling to preserve values in the `Debug` environment. Enabled Swagger for all non-production environments. Added `appsettings.Debug.json` for debugging-specific configuration.