### PR TITLE
Refactor profile creation to use AutoMapper

### DIFF
--- a/Authentication.Application/Features/CreateProfile/CreateProfileHandler.cs
+++ b/Authentication.Application/Features/CreateProfile/CreateProfileHandler.cs
@@ -45,8 +45,7 @@ namespace Authentication.Application.Features.CreateProfile
 
                 //Rabbitmq publish
                 string routingKey = "auth.create.user";
-                var message = new NewUserMessage(newUser.Id);
-
+                var message = _mapper.Map<NewUserMessage>(newUser);
                 _rabbitMqPublisher.Publish(routingKey, message);
             }
 

--- a/Authentication.Application/MappingProfile.cs
+++ b/Authentication.Application/MappingProfile.cs
@@ -2,6 +2,7 @@
 using Authentication.Application.Features.GetAllUsers;
 using Authentication.Application.Features.GetProfile;
 using Authentication.Application.Features.UpdateProfile;
+using Authentication.Application.RabbitMq.Models;
 using Authentication.Domain.Entities;
 using AutoMapper;
 namespace Authentication.Application
@@ -53,6 +54,13 @@ namespace Authentication.Application
                 .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.Email))
                 .ForMember(dest => dest.CreatedAt, opt => opt.MapFrom(src => src.CreatedAt))
                 .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id));
+
+            CreateMap<User, NewUserMessage>()
+                .ForMember(dest => dest.UserId, opt => opt.MapFrom(src => src.Id))
+                .ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.Email))
+                .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.FirstName))
+                .ForMember(dest => dest.MiddleName, opt => opt.MapFrom(src => src.Middlename))
+                .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.Lastname));
         }
     }
 }

--- a/Authentication.Application/RabbitMq/Models/NewUserMessage.cs
+++ b/Authentication.Application/RabbitMq/Models/NewUserMessage.cs
@@ -1,2 +1,11 @@
-﻿namespace Authentication.Application.RabbitMq.Models;
-    public sealed record NewUserMessage(int UserId);
+﻿namespace Authentication.Application.RabbitMq.Models
+{
+    public sealed class NewUserMessage
+    {
+        public required int UserId { get; set; }
+        public required string Email { get; set; }
+        public required string FirstName { get; set; }
+        public string? MiddleName { get; set; }
+        public string? LastName { get; set; }
+    }
+}


### PR DESCRIPTION
Refactored `CreateProfileHandler` to leverage AutoMapper for mapping `NewUserMessage`, replacing manual instantiation. Updated `MappingProfile` to include a mapping configuration for `User` to `NewUserMessage`. Expanded `NewUserMessage` structure by converting it to a class, adding new properties, and marking key fields as required. Improved maintainability by centralizing mapping logic and enhancing message structure for RabbitMQ communication.